### PR TITLE
fix: cli commands should interpret arguments as hex instead of converting strings to byte slices

### DIFF
--- a/x/cctp/client/cli/tx_replace_deposit_for_burn.go
+++ b/x/cctp/client/cli/tx_replace_deposit_for_burn.go
@@ -17,10 +17,13 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/circlefin/noble-cctp/x/cctp/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 )
 
@@ -36,12 +39,22 @@ func CmdReplaceDepositForBurn() *cobra.Command {
 				return err
 			}
 
+			destinationCaller, err := parseAddress(args[2])
+			if err != nil {
+				return fmt.Errorf("invalid destination caller: %w", err)
+			}
+
+			mintRecipient, err := parseAddress(args[3])
+			if err != nil {
+				return fmt.Errorf("invalid mint recipient: %w", err)
+			}
+
 			msg := &types.MsgReplaceDepositForBurn{
 				From:                 clientCtx.GetFromAddress().String(),
-				OriginalMessage:      []byte(args[0]),
-				OriginalAttestation:  []byte(args[1]),
-				NewDestinationCaller: []byte(args[2]),
-				NewMintRecipient:     []byte(args[3]),
+				OriginalMessage:      common.FromHex(args[0]),
+				OriginalAttestation:  common.FromHex(args[1]),
+				NewDestinationCaller: destinationCaller,
+				NewMintRecipient:     mintRecipient,
 			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)

--- a/x/cctp/client/cli/tx_replace_message.go
+++ b/x/cctp/client/cli/tx_replace_message.go
@@ -17,11 +17,15 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/circlefin/noble-cctp/x/cctp/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/spf13/cobra"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func CmdReplaceMessage() *cobra.Command {
@@ -36,12 +40,17 @@ func CmdReplaceMessage() *cobra.Command {
 				return err
 			}
 
+			destinationCaller, err := parseAddress(args[3])
+			if err != nil {
+				return fmt.Errorf("invalid destination caller: %w", err)
+			}
+
 			msg := &types.MsgReplaceMessage{
 				From:                 clientCtx.GetFromAddress().String(),
-				OriginalMessage:      []byte(args[0]),
-				OriginalAttestation:  []byte(args[1]),
-				NewMessageBody:       []byte(args[2]),
-				NewDestinationCaller: []byte(args[3]),
+				OriginalMessage:      common.FromHex(args[0]),
+				OriginalAttestation:  common.FromHex(args[1]),
+				NewMessageBody:       common.FromHex(args[2]),
+				NewDestinationCaller: destinationCaller,
 			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)

--- a/x/cctp/client/cli/tx_send_message.go
+++ b/x/cctp/client/cli/tx_send_message.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +54,7 @@ func CmdSendMessage() *cobra.Command {
 				From:              clientCtx.GetFromAddress().String(),
 				DestinationDomain: uint32(destinationDomain),
 				Recipient:         recipient,
-				MessageBody:       []byte(args[2]),
+				MessageBody:       common.FromHex(args[2]),
 			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)

--- a/x/cctp/client/cli/tx_send_message_with_caller.go
+++ b/x/cctp/client/cli/tx_send_message_with_caller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 )
 
@@ -58,7 +59,7 @@ func CmdSendMessageWithCaller() *cobra.Command {
 				From:              clientCtx.GetFromAddress().String(),
 				DestinationDomain: uint32(destinationDomain),
 				Recipient:         recipient,
-				MessageBody:       []byte(args[2]),
+				MessageBody:       common.FromHex(args[2]),
 				DestinationCaller: destinationCaller,
 			}
 


### PR DESCRIPTION
cli commands for replace deposit for burn, replace message, send message, and send message with caller interpret their arguments for messages, attestations and addresses as strings directly converted to byte slices. This makes these commands difficult to use and inconsistent with how the cli commands for deposit for burn handle addresses (converting from hex) and how receive message handles messages/attestations (converting from hex). This changes the latter commands to interpret their arguments as hex.